### PR TITLE
ci: verificar se os links dos artigos estão válidos

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -1,0 +1,19 @@
+name: Checar os links em .md
+
+on:
+  schedule:
+    - cron: "0 */24 * * *"
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  check-link:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Project checkout
+      uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+  


### PR DESCRIPTION
Verificar se os links de todos os arquivos `.md` estão válidos.

> Link válido é aquele que retorna status code 200.

A verificação é feita:
1. A cada `pull request` e `push`
1. A cada 24h via cronjob
1. De forma manual

Essa action foi executada com [sucesso no meu fork](https://github.com/PauloGoncalvesBH/cafe-com-testes/runs/1718704695).