### PR TITLE
fix: fix git vulnerability error on action

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -14,8 +14,10 @@ jobs:
 
     steps:
     - name: Project checkout
-      uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: actions/checkout@v3
+
+    # Fix emergencial para corrigir erro fatal: unsafe repository na action
+    - uses: labeneko/github-action-markdown-link-check@fixed-unsafe-repository
       with:
         check-modified-files-only: 'yes'
         base-branch: 'main'


### PR DESCRIPTION
Para fazer a checagem dos links apresentados no README do projeto é utilizado uma action `github-action-markdown-link-check` e recentemente houve uma vulnerabilidade encontrada no Git onde após a correção diversos repositórios passou a encontrar erros com a seguinte mensagem:
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

Para a correção foi utilizado o fork desse projeto feito por uma pessoa terceira, a mesma na qual abriu um PR de correção do problema para o repositório oficial da action https://github.com/gaurav-nelson/github-action-markdown-link-check/pull/133

sendo assim a action utilizada está sendo essa:
```
- uses: labeneko/github-action-markdown-link-check@fixed-unsafe-repository
      with:
        check-modified-files-only: 'yes'
        base-branch: 'main'
```

A action oficial foi comentada no projeto para que seja utilizada novamente quando a correção for mergeada.

Link da vulnerabilidade: https://github.blog/2022-04-12-git-security-vulnerability-announced/

Link da issue no repo da action: https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/132
Link do PR de correção no repo da action: https://github.com/gaurav-nelson/github-action-markdown-link-check/pull/133