### PR TITLE
ci: restore markdown link check action default

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -16,8 +16,7 @@ jobs:
     - name: Project checkout
       uses: actions/checkout@v3
 
-    # Fix emergencial para corrigir erro fatal: unsafe repository na action
-    - uses: labeneko/github-action-markdown-link-check@fixed-unsafe-repository
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         check-modified-files-only: 'yes'
         base-branch: 'main'


### PR DESCRIPTION
Restaura a action default de checagem de links no markdown, visto que a correção foi implementada na action original