### PR TITLE
ci: adjust runner for workflow check-link

### DIFF
--- a/.github/workflows/check-link.yml
+++ b/.github/workflows/check-link.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-link:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Project checkout


### PR DESCRIPTION
# Descrição
Ajustado a máquina de execução (runner) do job check-link que estava quebrando por utilizar o runner ubuntu-18.04 que foi depreciado.